### PR TITLE
SixLabors.ImageSharp NuGet Updates 

### DIFF
--- a/Source/YoloV8.Tests/YoloV8.Tests.csproj
+++ b/Source/YoloV8.Tests/YoloV8.Tests.csproj
@@ -18,8 +18,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="xunit" Version="2.7.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+		<PackageReference Include="xunit" Version="2.8.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Source/YoloV8/YoloV8.csproj
+++ b/Source/YoloV8/YoloV8.csproj
@@ -28,7 +28,7 @@
 		<PackageTags>image-classification object-detection pose-estimation instance-segmentation onnx imagesharp onnx-runtime ultralytics yolov8</PackageTags>
 		<PackageIcon>Icon.png</PackageIcon>
 		<Authors>Compunet</Authors>
-		<Version>4.0.0</Version>
+		<Version>4.1.5</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Source/YoloV8/YoloV8.csproj
+++ b/Source/YoloV8/YoloV8.csproj
@@ -28,7 +28,7 @@
 		<PackageTags>image-classification object-detection pose-estimation instance-segmentation onnx imagesharp onnx-runtime ultralytics yolov8</PackageTags>
 		<PackageIcon>Icon.png</PackageIcon>
 		<Authors>Compunet</Authors>
-		<Version>4.1.5</Version>
+		<Version>4.0.0</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -37,9 +37,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
-		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.2" />
-		<PackageReference Condition="'$(Configuration)' != 'GpuRelease'" Include="Microsoft.ML.OnnxRuntime" Version="1.17.1" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.3" />
+		<PackageReference Condition="'$(Configuration)' != 'GpuRelease'" Include="Microsoft.ML.OnnxRuntime" Version="1.17.3" />
 		<PackageReference Condition="'$(Configuration)' == 'GpuRelease'" Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.17.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
Updated the SixLabors.ImageSharp NuGets so no longer a transitive reference that has to be overridden